### PR TITLE
Fix magic with arguments that have a dash

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -651,7 +651,7 @@ class ParsedOptions(dict):
         return "{%s}" % ",\n ".join("%r: %r" % i for i in sorted(self.items()))
 
     def __getattr__(self, name: str) -> Optional[Union[str, bool]]:
-        return self.get(name) or {name: self.get(k) for k in self.keys() if name in [k.lstrip("-"), k.lstrip("<").rstrip(">")]}.get(name)
+        return self.get(name) or {name: self.get(k) for k in self.keys() if name in [k.lstrip("-").replace("-", "_"), k.lstrip("<").rstrip(">")]}.get(name)
 
 
 def docopt(

--- a/tests/test_docopt_ng.py
+++ b/tests/test_docopt_ng.py
@@ -143,3 +143,32 @@ def test_docopt_ng__doc__if_no_doc_indirection():
         return test_indirect()
 
     assert test_even_more_indirect() == {"--long": ""}
+
+
+def test_docopt_ng_dot_access_with_dash():
+    doc = """Usage: prog [-vqrd] [FILE]
+              prog INPUT OUTPUT
+              prog --help
+
+    Options:
+      -d --dash-arg  test this argument
+      -v             print status messages
+      -q             report only file names
+      -r             show all occurrences of the same error
+      --help
+
+    """
+    arguments = docopt.docopt(doc, "-v -d file.py")
+    assert arguments == {
+        "--dash-arg": True,
+        "-v": True,
+        "-q": False,
+        "-r": False,
+        "--help": False,
+        "FILE": "file.py",
+        "INPUT": None,
+        "OUTPUT": None,
+    }
+    assert arguments.v == True
+    assert arguments.FILE == "file.py"
+    assert arguments.dash_arg == True


### PR DESCRIPTION
I'd like to be able to support arguments that look like this:

`-a --argument-name    This is the argument to test`

This PR enables dot access as before but converts the name to `arguments.argument_name`.