### PR TITLE
Expose DocoptExit exception in the __all__

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -29,7 +29,7 @@ import inspect
 
 from typing import Any, List, Optional, Tuple, Type, Union, Dict, Callable
 
-__all__ = ["docopt", "magic_docopt", "magic"]
+__all__ = ["docopt", "magic_docopt", "magic", "DocoptExit"]
 __version__ = "0.7.2"
 
 


### PR DESCRIPTION
Let users to raise DocoptExit from their code to indicate an error in the arguments.
This is often required when arguments need to go through additional validation